### PR TITLE
Update wordpress-varnish-as-a-service.php

### DIFF
--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,11 +1,11 @@
 <?php
 /*
 Plugin Name: UCF WordPress Varnish as a Service
-Version: 1.2.2
-Author: Joan Artés (UCF fork)
+Version: 1.0.1
+Author: Joan Artés forked and modified by UCF
 Author URI: http://joanartes.com/
 Plugin URI: https://github.com/UCF/WordPress-Varnish-as-a-Service/
-Description: A UCF modified plugin for purging and banning Varnish cache when content is published or edited. It works with HTTP purge and Admin Port purge. Works with Varnish 2 (PURGE) and Varnish 3 (BAN) versions. Based on WordPress Varnish and Plugin Varnish Purges. This is a fork of the original plugin modified for use with UCF Varnish http BAN method.
+Description: A UCF modified plugin for purging and banning Varnish cache when content is published or edited. This is a fork of the original plugin modified for use with UCF Varnish http BAN method.
 */
 class WPVarnish {
 	public $commenter;

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: UCF WordPress Varnish as a Service
-Version: 1.2.3
+Version: 1.2.5
 Author: Joan Artés forked and modified by UCF
 Author URI: http://joanartes.com/
 Plugin URI: https://github.com/UCF/WordPress-Varnish-as-a-Service/

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: UCF WordPress Varnish as a Service
-Version: 1.0.1
+Version: 1.2.3
 Author: Joan Artés forked and modified by UCF
 Author URI: http://joanartes.com/
 Plugin URI: https://github.com/UCF/WordPress-Varnish-as-a-Service/

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,11 +1,11 @@
 <?php
 /*
-Plugin Name: WordPress Varnish as a Service
-Version: 1.2.1
-Author: Joan Artés
+Plugin Name: UCF WordPress Varnish as a Service
+Version: 1.2.2
+Author: Joan Artés (UCF fork)
 Author URI: http://joanartes.com/
-Plugin URI: http://joanartes.com/wordpress-varnish-as-a-service/
-Description: A plugin for purging Varnish cache when content is published or edited. It works with HTTP purge and Admin Port purge. Works with Varnish 2 (PURGE) and Varnish 3 (BAN) versions. Based on WordPress Varnish and Plugin Varnish Purges.
+Plugin URI: https://github.com/UCF/WordPress-Varnish-as-a-Service/
+Description: A UCF modified plugin for purging and banning Varnish cache when content is published or edited. It works with HTTP purge and Admin Port purge. Works with Varnish 2 (PURGE) and Varnish 3 (BAN) versions. Based on WordPress Varnish and Plugin Varnish Purges. This is a fork of the original plugin modified for use with UCF Varnish http BAN method.
 */
 class WPVarnish {
 	public $commenter;


### PR DESCRIPTION
It was commented that our fork of this plugin can't be differentiated from the original. Updated Plugin information to indicate this is the UCF version. Comments, suggestions, feedback are welcome and encouraged. Not sure if these changes are the right way to approach this fork or not. 
