### PR TITLE
Rc v1.2.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jartes, JavierCasares
 Tags: varnish, cache, purge, ban
 Requires at least: 2.5
 Tested up to: 4.7.2
-Stable tag: 1.2.3
+Stable tag: 1.2.2
 
 Clear your Varnish cache when new, edited or deleted content happens.
 
@@ -26,9 +26,6 @@ Based on <a href="http://wordpress.org/extend/plugins/wordpress-varnish/">WordPr
 1. Configuration.
 
 == Changelog ==
-
-= 1.2.3 =
- * Minor update
 
 = 1.2.2 =
  * WordPress 4.7.2 compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jartes, JavierCasares
 Tags: varnish, cache, purge, ban
 Requires at least: 2.5
 Tested up to: 4.7.2
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 
 Clear your Varnish cache when new, edited or deleted content happens.
 
@@ -26,6 +26,9 @@ Based on <a href="http://wordpress.org/extend/plugins/wordpress-varnish/">WordPr
 1. Configuration.
 
 == Changelog ==
+
+= 1.2.3 =
+ * Minor update
 
 = 1.2.2 =
  * WordPress 4.7.2 compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: jartes, JavierCasares
 Tags: varnish, cache, purge, ban
 Requires at least: 2.5
-Tested up to: 4.1
-Stable tag: 1.2.1
+Tested up to: 4.7.2
+Stable tag: 1.2.2
 
 Clear your Varnish cache when new, edited or deleted content happens.
 
@@ -26,6 +26,11 @@ Based on <a href="http://wordpress.org/extend/plugins/wordpress-varnish/">WordPr
 1. Configuration.
 
 == Changelog ==
+
+= 1.2.2 =
+ * WordPress 4.7.2 compatibility
+ * Fix minor bug
+ * PHP7 Compatible
 
 = 1.2.1 =
  * WordPress 4 compatibility

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WordPress Varnish as a Service
-Version: 1.2.2
+Version: 1.2.3
 Author: Joan Artés
 Author URI: http://joanartes.com/
 Plugin URI: http://joanartes.com/wordpress-varnish-as-a-service/

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WordPress Varnish as a Service
-Version: 1.2.1
+Version: 1.2.2
 Author: Joan Artés
 Author URI: http://joanartes.com/
 Plugin URI: http://joanartes.com/wordpress-varnish-as-a-service/
@@ -496,7 +496,7 @@ class WPVarnish {
 					$out .= "Connection: Close\r\n\r\n";
 					fwrite($varnish_sock, $out);
 					$buf = fread($varnish_sock, 256);
-					if(preg_match('/200 OK/', $buf) || preg_match('/404/', $buf)) {
+					if(preg_match('/200 OK/', $buf)) {
 						$varnish_test_conn .= "<li><span style=\"color: green;\">".__("OK - Request",'wp-varnish-aas')."</span></li>\n";
 					} else {
 						$varnish_test_conn .= "<li><span style=\"color: red;\">".__("KO - Request",'wp-varnish-aas')."</span></li>\n";

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WordPress Varnish as a Service
-Version: 1.2.3
+Version: 1.2.2
 Author: Joan Artés
 Author URI: http://joanartes.com/
 Plugin URI: http://joanartes.com/wordpress-varnish-as-a-service/
@@ -313,7 +313,7 @@ class WPVarnish {
 	function WPVarnishPurgeObject($wpv_url) {
 		global $varnish_servers;
 		$j=0;
-		if(get_option("wpvarnish_server")) {
+		if(get_option("wpvarnish_server_1")) {
 			$array_wpv_purgeaddr[$j] = get_option("wpvarnish_addr_1");
 			$array_wpv_purgeport[$j] = get_option("wpvarnish_port_1");
 			$array_wpv_secret[$j] = get_option("wpvarnish_secret_1");
@@ -348,7 +348,7 @@ class WPVarnish {
 			$wpv_use_adminport = $array_wpv_use_adminport[$i];
 			$wpv_use_version = $array_wpv_use_version[$i];
 			$wpv_wpurl = get_bloginfo('wpurl');
-			$wpv_replace_wpurl = '/^http:\/\/([^\/]+)(.*)/i';
+			$wpv_replace_wpurl = '/^https?:\/\/([^\/]+)(.*)/i';
 			$wpv_host = preg_replace($wpv_replace_wpurl, "$1", $wpv_wpurl);
 			$wpv_blogaddr = preg_replace($wpv_replace_wpurl, "$2", $wpv_wpurl);
 			$wpv_url = $wpv_blogaddr.$wpv_url;
@@ -381,10 +381,17 @@ class WPVarnish {
 						fwrite($varnish_sock, $out."\n");
 					}
 				} else {
-					$out = "PURGE $wpv_url HTTP/1.0\r\n";
-					$out .= "Host: $wpv_host\r\n";
-					$out .= "Connection: Close\r\n\r\n";
-					fwrite($varnish_sock, $out);
+					if ($wpv_use_version == 3) {
+						$out = "BAN HTTP/1.0\r\n";
+						$out .= "X-Ban-Url: $wpv_url\r\n";
+						$out .= "X-Ban-Host: $wpv_host\r\n";
+						$out .= "Connection: Close\r\n\r\n";
+					} else {	
+						$out = "PURGE $wpv_url HTTP/1.0\r\n";
+						$out .= "Host: $wpv_host\r\n";
+						$out .= "Connection: Close\r\n\r\n";
+					}	
+					fwrite($varnish_sock, $out."\n");
 				}
 				fclose($varnish_sock);
 			}
@@ -415,8 +422,8 @@ class WPVarnish {
 			$wpv_use_adminport = get_option("wpvarnish_use_adminport_3");
 			$wpv_use_version = get_option("wpvarnish_use_version_3");
 		}
-		$wpv_wpurl = get_bloginfo("url");
-		$wpv_replace_wpurl = '/^http:\/\/([^\/]+)(.*)/i';
+		$wpv_wpurl = get_bloginfo("wpurl");
+		$wpv_replace_wpurl = '/^https?:\/\/([^\/]+)(.*)/i';
 		$wpv_host = preg_replace($wpv_replace_wpurl, "$1", $wpv_wpurl);
 		$wpv_url = $wpv_blogaddr."/";
 		$varnish_test_conn .= "<ul>\n";
@@ -468,16 +475,32 @@ class WPVarnish {
 					}
 				}
 			} else {
-				$varnish_test_conn .= "<li><span style=\"color: blue;\">".__("INFO - HTTP Purge",'wp-varnish-aas')."</span></li>\n";
-				$out = "PURGE $wpv_url HTTP/1.0\r\n";
-				$out .= "Host: $wpv_host\r\n";
-				$out .= "Connection: Close\r\n\r\n";
-				fwrite($varnish_sock, $out);
-				$buf = fread($varnish_sock, 256);
-				if(preg_match('/200 OK/', $buf)) {
-					$varnish_test_conn .= "<li><span style=\"color: green;\">".__("OK - Request",'wp-varnish-aas')."</span></li>\n";
+				if ($wpv_use_version == 3) {
+					$varnish_test_conn .= "<li><span style=\"color: blue;\">".__("INFO - HTTP BAN",'wp-varnish-aas')."</span></li>\n";
+					$out = "BAN HTTP/1.0\r\n";
+					$out .= "X-Ban-Url: $wpv_url\r\n";
+					$out .= "X-Ban-Host: $wpv_host\r\n";
+					$out .= "Connection: Close\r\n\r\n";
+					fwrite($varnish_sock, $out."\n");
+					$buf = fread($varnish_sock, 256);
+					if(preg_match('/200/', $buf)) {
+						$varnish_test_conn .= "<li><span style=\"color: green;\">".__("OK - Cache flush",'wp-varnish-aas')."</span></li>\n";
+					} else {
+						$varnish_test_conn .= "<li><span style=\"color: red;\">".__("KO - Cache flush",'wp-varnish-aas')."</span><br><small>".__("Verify your Varnish version",'wp-varnish-aas')."</small></li>\n";
+					}
+
 				} else {
-					$varnish_test_conn .= "<li><span style=\"color: red;\">".__("KO - Request",'wp-varnish-aas')."</span></li>\n";
+					$varnish_test_conn .= "<li><span style=\"color: blue;\">".__("INFO - HTTP Purge",'wp-varnish-aas')."</span></li>\n";
+					$out = "PURGE $wpv_url HTTP/1.0\r\n";
+					$out .= "Host: $wpv_host\r\n";
+					$out .= "Connection: Close\r\n\r\n";
+					fwrite($varnish_sock, $out);
+					$buf = fread($varnish_sock, 256);
+					if(preg_match('/200 OK/', $buf)) {
+						$varnish_test_conn .= "<li><span style=\"color: green;\">".__("OK - Request",'wp-varnish-aas')."</span></li>\n";
+					} else {
+						$varnish_test_conn .= "<li><span style=\"color: red;\">".__("KO - Request",'wp-varnish-aas')."</span></li>\n";
+					}
 				}
 			}
 			fclose($varnish_sock);


### PR DESCRIPTION
Merged in changes from the official WordPress svn v1.2.2 and v1.2.3. It appears there were not many changes. the only change between v1.2.2 and v1.2.3 in the official svn repo was that v1.2.2 didn't have the version string incremented (upgrade loop).