### PR TITLE
Attachment handling

### DIFF
--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -51,7 +51,7 @@ class WPVarnish {
 		if(!get_option("wpvarnish_server_1"))
 			add_option("wpvarnish_server_1", $wpv_server_optval_1, '', 'yes');
 
-    if(!get_option("wpvarnish_addr_2"))
+	if(!get_option("wpvarnish_addr_2"))
 			add_option("wpvarnish_addr_2", $wpv_addr_optval_2, '', 'yes');
 		if(!get_option("wpvarnish_port_2"))
 			add_option("wpvarnish_port_2", $wpv_port_optval_2, '', 'yes');
@@ -81,7 +81,7 @@ class WPVarnish {
 		if(!get_option("wpvarnish_server_3"))
 			add_option("wpvarnish_server_3", $wpv_server_optval_3, '', 'yes');
 
-    add_action('init', array(&$this, 'WPVarnishLocalization'));
+	add_action('init', array(&$this, 'WPVarnishLocalization'));
 		add_action('admin_menu', array(&$this, 'WPVarnishAdminMenu'));
 		add_action('edit_post', array(&$this, 'WPVarnishPurgePost'), 99);
 		add_action('edit_post', array(&$this, 'WPVarnishPurgeCommonObjects'), 99);
@@ -93,8 +93,8 @@ class WPVarnish {
 		add_action('deleted_post', array(&$this, 'WPVarnishPurgePost'), 99);
 		add_action('deleted_post', array(&$this, 'WPVarnishPurgeCommonObjects'), 99);
 		add_action('add_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
-        add_action('edit_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
-        add_action('delete_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
+		add_action('edit_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
+		add_action('delete_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
 		add_filter('wp_get_current_commenter', array(&$this, "wp_get_current_commenter_varnish"));
 	}
 	function wp_get_current_commenter_varnish($commenter) {


### PR DESCRIPTION
Ports over attachment url banning/purging from the [Varnish Dependency Purge plugin](https://github.com/UCF/VarnishDependencyPurge/blob/master/varnish-dependency-purge.php#L282-L297), so that attachment urls can be banned when they are created/updated/deleted.

I tried to match the existing code style instead of our typical style guide in case we wanted to submit this to the original repo.