### PR TITLE
Fb clear cache on permalink update

### DIFF
--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -59,7 +59,9 @@ class WPVarnish {
 		add_action('wp_delete_nav_menu', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('wp_add_nav_menu_item', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('wp_update_nav_menu_item', array(&$this, 'WPVarnishPurgeAll'), 99);
-		add_action('update_option_permalink_structure', array(&$this, 'WPVarnishPurgeAll'), 99);
+		add_action('update_option_category_base', array(&$this, 'WPVarnishPurgeAll'), 99);
+		add_action('update_option_tag_base', array(&$this, 'WPVarnishPurgeAll'), 99);
+		add_action('permalink_structure_changed', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_filter('wp_get_current_commenter', array(&$this, "wp_get_current_commenter_varnish"));
 	}
 	// Wordpress function 'get_site_option' and 'get_option'

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -62,7 +62,6 @@ class WPVarnish {
 		add_action('update_option_category_base', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('update_option_tag_base', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('permalink_structure_changed', array(&$this, 'WPVarnishPurgeAll'), 99);
-		add_action('update_option_permalink_structure', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_filter('wp_get_current_commenter', array(&$this, "wp_get_current_commenter_varnish"));
 	}
 	// Wordpress function 'get_site_option' and 'get_option'

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -62,6 +62,7 @@ class WPVarnish {
 		add_action('update_option_category_base', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('update_option_tag_base', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_action('permalink_structure_changed', array(&$this, 'WPVarnishPurgeAll'), 99);
+		add_action('update_option_permalink_structure', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_filter('wp_get_current_commenter', array(&$this, "wp_get_current_commenter_varnish"));
 	}
 	// Wordpress function 'get_site_option' and 'get_option'

--- a/wordpress-varnish-as-a-service.php
+++ b/wordpress-varnish-as-a-service.php
@@ -55,6 +55,7 @@ class WPVarnish {
 		add_action('add_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
 		add_action('edit_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
 		add_action('delete_attachment', array(&$this, 'WPVarnishPurgeAttachment'), 99);
+		add_action('update_option_permalink_structure', array(&$this, 'WPVarnishPurgeAll'), 99);
 		add_filter('wp_get_current_commenter', array(&$this, "wp_get_current_commenter_varnish"));
 	}
 	// Wordpress function 'get_site_option' and 'get_option'


### PR DESCRIPTION
https://github.com/UCF/UCF-WordPress-Varnish-as-a-Service/issues/16

Hook used:
update_option_category_base - 
update_option_permalink_structure - 
update_option_tag_base - 
https://developer.wordpress.org/reference/hooks/update_option_option/

permalink_structure_changed -
https://developer.wordpress.org/reference/hooks/permalink_structure_changed/

